### PR TITLE
Update README.md w/ Linker.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ For detailed instruction go to the [Wiki page](https://github.com/mariusmuntean/
     .
 ```
 
+3. Add Linker.xml (e.g. from https://github.com/mariusmuntean/ChartJs.Blazor/blob/master/samples/ChartJs.Blazor.Sample/Linker.xml) to your project.
+4. Edit the .csproj file as follows
+
+```xml
+  <ItemGroup>
+    <BlazorLinkerDescriptor Include="Linker.xml" />
+  </ItemGroup>
+```
+
 
 ## Samples
 


### PR DESCRIPTION
Added description how to add Linker.xml.
Without it, the example will not work (because System.ComponentModel.ReferenceConverter is being optimized away)